### PR TITLE
Enable export workouts 

### DIFF
--- a/wger/manager/templates/workout/overview.html
+++ b/wger/manager/templates/workout/overview.html
@@ -33,4 +33,30 @@
 <a href="{% url 'manager:workout:add' %}" class="btn btn-success btn-sm">
     {% trans "Add workout" %}
 </a>
+<div class="modal fade" id="export_workout">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title">{% trans "Import Workout" %}</h4>
+                </div>
+            <div class="modal-body">
+                <form action="{% url 'manager:workout:export_workouts' %}" method="post" enctype="multipart/form-data">{% csrf_token %}
+                    <h5>
+                        <strong>{% trans "Import from CSV file" %}:</strong>
+                    </h5>
+                    <p>
+                        <input type="file" name="csv_file" />
+                    </p>
+                    <input type="submit" value="Import" class="btn btn-success btn-sm" />  </form>
+                 </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Close" %}</button>
+                 </div>
+             </div>
+         </div>
+</div>
+<a data-toggle="modal" data-target="#export_workout" class="btn btn-default btn-sm">
+     {% trans "Import Workouts" %}
+</a>
 {% endblock %}

--- a/wger/manager/templates/workout/view.html
+++ b/wger/manager/templates/workout/view.html
@@ -231,6 +231,12 @@ an appointment for each training day with the appropriate exercises.{% endblockt
                {% trans "View weight log" %}
             </a>
         </li>
+        <li>
+            <a href='{% url 'manager:workout:export_workouts' workout.id %}'>
+                <span class="{% fa_class 'download' %}"></span>
+                {% trans "Export workout" %}
+            </a>
+        </li>
         {% if is_owner %}
         <li>
             <a href="{% url 'manager:workout:edit' workout.id %}" class="wger-modal-dialog">

--- a/wger/manager/urls.py
+++ b/wger/manager/urls.py
@@ -112,6 +112,9 @@ patterns_workout = [
     url(r'^(?P<day_pk>\d+)/timer$',
         workout.timer,
         name='timer'),
+    url(r'^(?P<pk>\d+)/export/$', workout.export_workout,
+        name='export_workouts'),
+    url(r'^import/$', workout.import_workout, name='export_workouts'),
 ]
 
 

--- a/wger/manager/views/workout.py
+++ b/wger/manager/views/workout.py
@@ -17,26 +17,31 @@
 import logging
 import uuid
 import datetime
+import csv
+from io import TextIOWrapper
 
 from django.shortcuts import render, get_object_or_404
-from django.http import HttpResponseRedirect, HttpResponseForbidden
+from django.http import HttpResponseRedirect, HttpResponseForbidden, HttpResponse
 from django.template.context_processors import csrf
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.utils.translation import ugettext_lazy, ugettext as _
 from django.contrib.auth.mixins import PermissionRequiredMixin, LoginRequiredMixin
 from django.contrib.auth.decorators import login_required
 from django.views.generic import DeleteView, UpdateView
+from wger.exercises.models import Exercise
 
 from wger.core.models import (
     RepetitionUnit,
-    WeightUnit
+    WeightUnit,
+    DaysOfWeek
 )
 from wger.manager.models import (
     Workout,
     WorkoutSession,
     WorkoutLog,
     Schedule,
-    Day
+    Day,
+    Set
 )
 from wger.manager.forms import (
     WorkoutForm,
@@ -388,3 +393,91 @@ def timer(request, day_pk):
     context['weight_units'] = WeightUnit.objects.all()
     context['repetition_units'] = RepetitionUnit.objects.all()
     return render(request, 'workout/timer.html', context)
+
+@login_required
+def export_workout(request, pk):
+    '''export workout as csv'''
+
+    workouts = Workout.objects.filter(user=request.user, id=pk)
+
+    #  type of response
+    response = HttpResponse(content_type='text/csv')
+
+    response['Content-Disposition'] = 'attachment; filename=' + \
+        str(request.user) + '_workouts.csv'
+    writer = csv.writer(response)
+
+    # row names for the csv file
+    writer.writerow(['Date Created', 'Comment', 'Days', 'Description', 'Exercise'])
+
+    for workout in workouts:
+        # get workout days
+        trainind_days = Day.objects.filter(training=workout.id)
+        for day in trainind_days:
+            workout_days = "\n".join(
+                    [item.day_of_week for item in day.day.all()]
+                    )
+
+            # get the exercises
+            sets = Set.objects.filter(exerciseday=day.id)
+            for one_set in sets:
+                exercises = "\n".join(
+                        [exercise.name for exercise in one_set.exercises.all()]
+                        )
+                # write the data to the csv file
+                writer.writerow([
+                    workout.creation_date,
+                    workout.comment,
+                    workout_days,
+                    day.description,
+                    exercises
+                    ])
+    return response
+
+
+@login_required
+def import_workout(request):
+    ''' implements the Importing csv files '''
+    if request.POST and request.FILES:
+        # Gets the csv files and converts it to a standard format
+        csv_file = TextIOWrapper(
+            request.FILES['csv_file'].file,
+            encoding="utf-8"
+        )
+
+        reader = csv.DictReader(csv_file)
+        workout = []
+
+        # assign the content in the csv to workout list
+        for row in reader:
+            workout.append(dict(row))
+
+        for single_workout in workout:
+
+            # extract the workout from the list and save it
+            a_workout = Workout(
+                creation_date=single_workout["Date created"],
+                comment=single_workout["Comment"],
+                user=request.user
+                )
+            a_workout.save()
+
+            # extract the day from the workout and save
+            day = Day(
+                training=a_workout,
+                description=single_workout["Description"]
+                )
+            day.save()
+
+            # save the workout days
+            for day_name in single_workout["Days"].split("\n"):
+                day.day.add(DaysOfWeek.objects.filter(day_of_week=day_name).first())
+
+            single_set = Set(exerciseday=day)
+            single_set.save()
+
+            # save the exercises
+            for exercise in single_workout["Exercise"].split("\n"):
+                single_set.exercises.add(Exercise.objects.filter(name=exercise).first())
+
+    return HttpResponseRedirect(reverse('manager:workout:overview'))

--- a/wger/manager/views/workout.py
+++ b/wger/manager/views/workout.py
@@ -453,10 +453,9 @@ def import_workout(request):
             workout.append(dict(row))
 
         for single_workout in workout:
-
             # extract the workout from the list and save it
             a_workout = Workout(
-                creation_date=single_workout["Date created"],
+                creation_date=single_workout["Date Created"],
                 comment=single_workout["Comment"],
                 user=request.user
                 )


### PR DESCRIPTION
**What does this PR do?**

- Enables users to export and import workouts


**Description of tasks to be completed**

- A user should be able to export their workout data as a CSV file.
- A user should also be able to import data from a CSV file to their workout data.

**How can this be tested manually?**

- Navigate to the workout page, create the workout, add exercises and training days.
- On the options dropdown, there is an option of exporting workouts which downloads CSV file.
- There is also an option to import workout data which then appears on the workout overview page.

- Relevant tracker stories 

- 157110626

**Screenshots**

Export workout option

<img width="1074" alt="screen shot 2018-05-23 at 3 32 00 pm" src="https://user-images.githubusercontent.com/17777137/40424549-9351b2c2-5e9e-11e8-9727-32d751c64f53.png">

Import workout option

<img width="949" alt="screen shot 2018-05-23 at 3 33 44 pm" src="https://user-images.githubusercontent.com/17777137/40424648-d301148a-5e9e-11e8-9f07-e1e5bba67400.png">

