### PR TITLE
Ft allow trainers deactivation 157110630

### DIFF
--- a/wger/exercises/signals.py
+++ b/wger/exercises/signals.py
@@ -21,8 +21,9 @@ from django.dispatch import receiver
 from easy_thumbnails.files import get_thumbnailer
 from easy_thumbnails.signal_handlers import generate_aliases
 from easy_thumbnails.signals import saved_file
+from django.core.cache import cache
 
-from wger.exercises.models import ExerciseImage
+from wger.exercises.models import ExerciseImage, Muscle
 
 
 @receiver(post_delete, sender=ExerciseImage)
@@ -34,6 +35,14 @@ def delete_exercise_image_on_delete(sender, instance, **kwargs):
     thumbnailer = get_thumbnailer(instance.image)
     thumbnailer.delete_thumbnails()
     instance.image.delete(save=False)
+
+
+@receiver(post_delete, sender=Muscle)
+def reset_exercise_cache_on_muscle_deletion(sender, instance, **kwargs):
+    """
+reseting cache  after a muscle has been deleted
+"""
+    cache.clear()
 
 
 @receiver(pre_save, sender=ExerciseImage)

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block content %}
-{% if perms.gym.manage_gym or perms.gym.gym_trainer %}
+{% if perms.gym.manage_gym or perms.gym.gym_trainer or permis.gym.manage_gyms %}
     <div>
         <a class="btn btn-success" href="members">All Users</a>
         <a class="btn btn-primary" href="members?group=active">Active Users</a>
@@ -30,6 +30,7 @@
     <th style="width: 10%;">{% trans "ID" %}</th>
     <th style="width: 40%;">{% trans "Username" %}</th>
     <th>{% trans "Name" %}</th>
+    <th>{% trans "Status" %}</th>
     {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
         <th style="text-align: right;">{% trans "Roles" %}</th>
     {% endif %}
@@ -42,8 +43,7 @@
         {{current_user.obj.pk}}
     </td>
     <td>
-        {{current_user.obj}}
-
+       {{current_user.obj}}
         {% if current_user.perms.gym_trainer %}
             <span class="label label-primary">{% trans "Trainer" %}</span>
         {% endif %}
@@ -59,6 +59,19 @@
     <td>
         {{current_user.obj.get_full_name}}
     </td>
+
+    {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+    <td style="text-align: left;">
+        {% if not current_user.perms.manage_gym and not current_user.perms.manage_gyms %}
+            {% if current_user.obj.is_active %}
+            <a href="{% url 'core:user:deactivate' current_user.obj.pk %}" class="btn btn-warning"><i class="fa fa-times-circle"></i> Deactivate</a>
+            {% else %}
+            <a href="{% url 'core:user:activate' current_user.obj.pk %}" class="btn btn-success"><i class="fa fa-check-circle"></i> Activate</a> |
+            <a href="{% url 'core:user:delete' current_user.obj.pk %}" class="btn btn-danger"><i class="fa fa-trash"></i> Delete</a>
+            {% endif %}
+            {% endif %}
+    </td>
+    {% endif %}
 
     {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
     <td style="text-align: right;">


### PR DESCRIPTION
###  What does this PR do?
Allow managers to delete or deactivate trainers from a gym
###  Description of Task to be completed?
Managers had no way of deactivating trainers, now they'll see a button for deactivation and deletion
### How should this be manually tested?
After Creating User with Trainer role , manager will see deactivation button
### Screenshot
<img width="757" alt="screen shot 2018-05-24 at 11 03 06" src="https://user-images.githubusercontent.com/5984570/40472446-341d42c2-5f42-11e8-8e26-eee429e4680a.png">
<img width="771" alt="screen shot 2018-05-24 at 11 03 26" src="https://user-images.githubusercontent.com/5984570/40472450-36a4cdc6-5f42-11e8-91c4-b5e18f243a6a.png">
<img width="745" alt="screen shot 2018-05-24 at 11 03 34" src="https://user-images.githubusercontent.com/5984570/40472452-39074332-5f42-11e8-907b-d2574adb2530.png">


### What are the relevant pivotal tracker stories?
[#157110630](https://www.pivotaltracker.com/story/show/157110630)
